### PR TITLE
Filter checks is being removed in 2.9

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,5 @@
 - name: Wait until boot is complete
   wait_for: host={{ip_to_probe}} port={{port_to_probe}} delay={{delay_before_probe}} timeout={{probe_timeout}}
   connection: local
-  when: reboot|changed or force_reboot
+  when: reboot is changed or force_reboot
   changed_when: True
-


### PR DESCRIPTION
This task is raising the following warning:

> [DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using
`result|changed` instead use `result is changed`. This feature will be removed
in version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.